### PR TITLE
implementation: Add task type breakdown to agent comparison metrics

### DIFF
--- a/backend/src/services/taskQueue.metrics.test.ts
+++ b/backend/src/services/taskQueue.metrics.test.ts
@@ -1,21 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import {
-  summarizeAgentComparisonMetrics,
-  type AgentComparisonMetrics,
-} from './taskQueue.sqlite.js';
+import { summarizeAgentComparisonMetrics } from './taskQueue.sqlite.js';
 
 describe('summarizeAgentComparisonMetrics', () => {
-  const zeroMetrics: AgentComparisonMetrics = {
-    claude: { total: 0, completed: 0, failed: 0, success_rate: 0 },
-    codex: { total: 0, completed: 0, failed: 0, success_rate: 0 },
-  };
+  const zeroAgentMetrics = { total: 0, completed: 0, failed: 0, success_rate: 0 };
 
   it('should return zeroed metrics when no stats exist', () => {
     const metrics = summarizeAgentComparisonMetrics([]);
     expect(metrics).toEqual(
       expect.objectContaining({
-        claude: expect.objectContaining(zeroMetrics.claude),
-        codex: expect.objectContaining(zeroMetrics.codex),
+        claude: expect.objectContaining(zeroAgentMetrics),
+        codex: expect.objectContaining(zeroAgentMetrics),
+      }),
+    );
+
+    expect(metrics.task_type_breakdown).toEqual(
+      expect.objectContaining({
+        claude: expect.objectContaining({
+          implementation: expect.objectContaining(zeroAgentMetrics),
+          testing: expect.objectContaining(zeroAgentMetrics),
+          documentation: expect.objectContaining(zeroAgentMetrics),
+        }),
+        codex: expect.objectContaining({
+          implementation: expect.objectContaining(zeroAgentMetrics),
+          testing: expect.objectContaining(zeroAgentMetrics),
+          documentation: expect.objectContaining(zeroAgentMetrics),
+        }),
       }),
     );
   });
@@ -32,7 +41,7 @@ describe('summarizeAgentComparisonMetrics', () => {
     expect(metrics.claude.success_rate).toBeCloseTo(70);
 
     // Codex should remain at defaults when no data exists
-    expect(metrics.codex).toEqual(expect.objectContaining(zeroMetrics.codex));
+    expect(metrics.codex).toEqual(expect.objectContaining(zeroAgentMetrics));
   });
 
   it('should compute metrics for both agents with fractional success rates', () => {
@@ -46,5 +55,53 @@ describe('summarizeAgentComparisonMetrics', () => {
 
     expect(metrics.codex.success_rate).toBeCloseTo((5 / 6) * 100);
     expect(metrics.codex.avg_duration_ms).toBe(2500);
+  });
+
+  it('should include task type breakdown for tracked task types', () => {
+    const metrics = summarizeAgentComparisonMetrics(
+      [
+        { agent_type: 'claude', total: 3, completed: 2, failed: 1, avg_duration_ms: 1500 },
+        { agent_type: 'codex', total: 2, completed: 2, failed: 0, avg_duration_ms: 2200 },
+      ],
+      [
+        {
+          agent_type: 'claude',
+          task_type: 'implementation',
+          total: 2,
+          completed: 2,
+          failed: 0,
+          avg_duration_ms: 1800,
+        },
+        {
+          agent_type: 'codex',
+          task_type: 'documentation',
+          total: 1,
+          completed: 1,
+          failed: 0,
+          avg_duration_ms: 2000,
+        },
+        {
+          agent_type: 'codex',
+          task_type: 'planning',
+          total: 5,
+          completed: 4,
+          failed: 1,
+          avg_duration_ms: 3000,
+        },
+      ],
+    );
+
+    expect(metrics.task_type_breakdown.claude.implementation).toEqual(
+      expect.objectContaining({
+        total: 2,
+        completed: 2,
+        failed: 0,
+        success_rate: 100,
+      }),
+    );
+    expect(metrics.task_type_breakdown.claude.testing).toEqual(expect.objectContaining(zeroAgentMetrics));
+    expect(metrics.task_type_breakdown.codex.documentation.avg_duration_ms).toBe(2000);
+    expect(metrics.task_type_breakdown.codex.testing).toEqual(expect.objectContaining(zeroAgentMetrics));
+    expect(metrics.task_type_breakdown.codex.implementation).toEqual(expect.objectContaining(zeroAgentMetrics));
   });
 });

--- a/backend/src/services/taskQueue.sqlite.ts
+++ b/backend/src/services/taskQueue.sqlite.ts
@@ -41,6 +41,15 @@ type AgentStatsRow = {
   avg_duration_ms: number | null;
 };
 
+type AgentTaskTypeStatsRow = AgentStatsRow & {
+  task_type: string;
+};
+
+const TRACKED_TASK_TYPES = ['implementation', 'testing', 'documentation'] as const;
+type TaskTypeKey = typeof TRACKED_TASK_TYPES[number];
+
+export type AgentTaskTypeBreakdown = Record<TaskTypeKey, AgentMetrics>;
+
 export type AgentMetrics = {
   total: number;
   completed: number;
@@ -52,9 +61,20 @@ export type AgentMetrics = {
 export type AgentComparisonMetrics = {
   claude: AgentMetrics;
   codex: AgentMetrics;
+  task_type_breakdown: {
+    claude: AgentTaskTypeBreakdown;
+    codex: AgentTaskTypeBreakdown;
+  };
 };
 
-export function summarizeAgentComparisonMetrics(agentStats: AgentStatsRow[]): AgentComparisonMetrics {
+const isTrackedTaskType = (value: string | null | undefined): value is TaskTypeKey => {
+  return Boolean(value) && TRACKED_TASK_TYPES.includes(value as TaskTypeKey);
+};
+
+export function summarizeAgentComparisonMetrics(
+  agentStats: AgentStatsRow[],
+  taskTypeStats: AgentTaskTypeStatsRow[] = [],
+): AgentComparisonMetrics {
   const buildMetrics = (stats?: AgentStatsRow): AgentMetrics => {
     const completed = stats?.completed ?? 0;
     const failed = stats?.failed ?? 0;
@@ -75,9 +95,31 @@ export function summarizeAgentComparisonMetrics(agentStats: AgentStatsRow[]): Ag
   const claudeStats = agentStats.find((s) => s.agent_type === 'claude');
   const codexStats = agentStats.find((s) => s.agent_type === 'codex');
 
+  const createEmptyBreakdown = (): AgentTaskTypeBreakdown => {
+    return TRACKED_TASK_TYPES.reduce((acc, taskType) => {
+      acc[taskType] = buildMetrics();
+      return acc;
+    }, {} as AgentTaskTypeBreakdown);
+  };
+
+  const breakdown = {
+    claude: createEmptyBreakdown(),
+    codex: createEmptyBreakdown(),
+  };
+
+  for (const stats of taskTypeStats) {
+    if (!isTrackedTaskType(stats.task_type)) {
+      continue;
+    }
+
+    const agentBucket = stats.agent_type === 'claude' ? breakdown.claude : breakdown.codex;
+    agentBucket[stats.task_type] = buildMetrics(stats);
+  }
+
   return {
     claude: buildMetrics(claudeStats),
     codex: buildMetrics(codexStats),
+    task_type_breakdown: breakdown,
   };
 }
 
@@ -1174,7 +1216,27 @@ export class TaskQueueService {
       GROUP BY agent_type
     `).all() as AgentStatsRow[];
 
-    return summarizeAgentComparisonMetrics(agentStats);
+    const taskTypeStats = this.db.prepare(`
+      SELECT
+        agent_type,
+        LOWER(type) as task_type,
+        COUNT(*) as total,
+        SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+        SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+        AVG(CASE
+          WHEN status = 'completed' AND completed_at IS NOT NULL AND started_at IS NOT NULL
+          THEN completed_at - started_at
+          ELSE NULL
+        END) as avg_duration_ms
+      FROM tasks
+      WHERE agent_type IS NOT NULL
+        AND agent_type IN ('claude', 'codex')
+        AND type IS NOT NULL
+        AND LOWER(type) IN ('implementation', 'testing', 'documentation')
+      GROUP BY agent_type, LOWER(type)
+    `).all() as AgentTaskTypeStatsRow[];
+
+    return summarizeAgentComparisonMetrics(agentStats, taskTypeStats);
   }
 
   /**

--- a/docs/dev-bots/task-queue.md
+++ b/docs/dev-bots/task-queue.md
@@ -125,6 +125,18 @@ curl http://localhost:5000/api/dev-bots/agent-comparison | jq '.'
       "failed": 5,
       "avg_duration_ms": 118250,
       "success_rate": 88.37
+    },
+    "task_type_breakdown": {
+      "claude": {
+        "implementation": { "total": 26, "completed": 25, "failed": 1, "success_rate": 96.15 },
+        "testing": { "total": 12, "completed": 10, "failed": 2, "success_rate": 83.33 },
+        "documentation": { "total": 7, "completed": 7, "failed": 0, "success_rate": 100 }
+      },
+      "codex": {
+        "implementation": { "total": 22, "completed": 18, "failed": 4, "success_rate": 81.82 },
+        "testing": { "total": 11, "completed": 9, "failed": 2, "success_rate": 81.82 },
+        "documentation": { "total": 10, "completed": 10, "failed": 0, "success_rate": 100 }
+      }
     }
   }
 }
@@ -139,6 +151,7 @@ curl http://localhost:5000/api/dev-bots/agent-comparison | jq '.'
 3. **`failed`**: Number of failed tasks
 4. **`avg_duration_ms`**: Average time to complete tasks (milliseconds)
 5. **`success_rate`**: Percentage of tasks completed successfully (0-100)
+6. **`task_type_breakdown`**: Nested stats for `implementation`, `testing`, and `documentation` showing strengths by work type.
 
 **Performance Analysis:**
 
@@ -157,6 +170,13 @@ curl http://localhost:5000/api/dev-bots/agent-comparison | \
     claude_avg_min: (.comparison.claude.avg_duration_ms / 60000),
     codex_avg_min: (.comparison.codex.avg_duration_ms / 60000),
     claude_faster: (.comparison.claude.avg_duration_ms < .comparison.codex.avg_duration_ms)
+  }'
+
+# Compare documentation success rates
+curl http://localhost:5000/api/dev-bots/agent-comparison | \
+  jq '{
+    claude_doc_success: .comparison.task_type_breakdown.claude.documentation.success_rate,
+    codex_doc_success: .comparison.task_type_breakdown.codex.documentation.success_rate
   }'
 ```
 
@@ -279,6 +299,22 @@ jq -r '.comparison |
   "Codex:  \((.codex.avg_duration_ms/60000) | round) minutes"'
 ```
 
+#### Agent comparison drilldowns
+
+See [SQLite Integration Plan – Agent Comparison Metrics](./SQLITE_INTEGRATION_PLAN.md#agent-comparison-metrics) for the full architecture. The quick commands below are handy when you just need a per-type snapshot:
+
+```bash
+# Task-type scoreboard grouped by agent
+curl -s http://localhost:5000/api/dev-bots/agent-comparison \
+  | jq '.comparison.task_type_breakdown \
+        | to_entries[] \
+        | {agent: .key, implementation: .value.implementation.success_rate, testing: .value.testing.success_rate, documentation: .value.documentation.success_rate}'
+
+# Raw breakdown data if you want to feed Grafana
+curl -s http://localhost:5000/api/dev-bots/agent-comparison \
+  | jq '.comparison.task_type_breakdown'
+```
+
 ---
 
 ## Best Practices
@@ -337,12 +373,20 @@ curl -X POST http://localhost:5000/api/dev-bots/tasks/TASK_ID/timeout \
 
 **Issue: Agent comparison metrics show no data**
 ```bash
+# Confirm API is reachable
+curl -s http://localhost:5000/api/dev-bots/agent-comparison | jq '.comparison'
+
 # Verify agent_type column exists
 sqlite3 ./data/tasks/queue.db "PRAGMA table_info(tasks)" | grep agent_type
 
 # Check if tasks have agent_type set
 sqlite3 ./data/tasks/queue.db "SELECT agent_type, COUNT(*) FROM tasks GROUP BY agent_type"
+
+# Inspect per-type breakdown to make sure new runs exist
+curl -s http://localhost:5000/api/dev-bots/agent-comparison \
+  | jq '.comparison.task_type_breakdown'
 ```
+See the [Agent Comparison Metrics](./SQLITE_INTEGRATION_PLAN.md#agent-comparison-metrics) section for a complete operator checklist.
 
 **Issue: Tasks not being assigned**
 ```bash


### PR DESCRIPTION
Enhance the TaskQueueService metrics pipeline to attach per-task-type stats for Claude and Codex along with documentation updates.