### PR TITLE
Remove --warning=no-file-changed flag from tar command

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -100,7 +100,6 @@ jobs:
           MANIFEST_NAME="${ARTIFACT_NAME}.manifest.json"
           
           # Create tarball with all necessary files
-          # Note: GNU tar is available on GitHub-hosted runners (Ubuntu)
           tar -czf "$TARBALL_NAME" \
             --exclude=node_modules \
             --exclude=.git \
@@ -111,7 +110,6 @@ jobs:
             --exclude=releases \
             --exclude=shared \
             --exclude='*.log' \
-            --warning=no-file-changed \
             .
           
           # Calculate checksum


### PR DESCRIPTION
The flag was causing tar to exit with non-zero status in CI, breaking the deployment workflow.