### PR TITLE
implementation: Add detectStaleBranch method to PR workflow orchestrator

### DIFF
--- a/backend/src/services/prWorkflowOrchestrator.service.test.ts
+++ b/backend/src/services/prWorkflowOrchestrator.service.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for PR Workflow Orchestrator Service - detectStaleBranch method
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PRWorkflowOrchestrator } from './prWorkflowOrchestrator.service.js';
+import { exec } from 'child_process';
+import type { TaskQueueService } from './taskQueue.sqlite.js';
+
+// Mock child_process exec
+vi.mock('child_process', () => ({
+  exec: vi.fn()
+}));
+
+// Mock logger
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn()
+  }
+}));
+
+// Mock PRMonitorService
+vi.mock('./prMonitor.service.js', () => ({
+  PRMonitorService: vi.fn().mockImplementation(() => ({
+    getStatus: vi.fn().mockReturnValue({})
+  }))
+}));
+
+// Mock PRArtifactRecoveryService
+vi.mock('./prArtifactRecovery.service.js', () => ({
+  PRArtifactRecoveryService: vi.fn().mockImplementation(() => ({
+    recoverOrphanedPRs: vi.fn().mockResolvedValue({
+      prInfoRecovered: 0,
+      tasksUpdated: 0,
+      artifactsProcessed: 0
+    })
+  }))
+}));
+
+// Mock getGitHubPRService
+vi.mock('./githubPR.service.js', () => ({
+  getGitHubPRService: vi.fn().mockReturnValue({})
+}));
+
+describe('PRWorkflowOrchestrator - detectStaleBranch', () => {
+  let orchestrator: PRWorkflowOrchestrator;
+  let mockTaskQueue: TaskQueueService;
+
+  beforeEach(() => {
+    // Create mock task queue
+    mockTaskQueue = {
+      getTasksWithUnmergedPRs: vi.fn().mockResolvedValue([]),
+      updateTask: vi.fn().mockResolvedValue(undefined)
+    } as unknown as TaskQueueService;
+
+    orchestrator = new PRWorkflowOrchestrator(mockTaskQueue);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('detectStaleBranch', () => {
+    it('should detect branch is up to date (not stale)', async () => {
+      // Mock git commands
+      const mockExec = vi.mocked(exec);
+
+      // Mock merge-base command
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: 'abc123def456\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits behind (0 commits)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '0\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits ahead (5 commits)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '5\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      const result = await orchestrator.detectStaleBranch('feature-branch', 'main', '/repo');
+
+      expect(result).toEqual({
+        isStale: false,
+        commitsBehind: 0,
+        commitsAhead: 5,
+        mergeBase: 'abc123def456'
+      });
+    });
+
+    it('should detect branch is stale (behind base)', async () => {
+      const mockExec = vi.mocked(exec);
+
+      // Mock merge-base command
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: 'xyz789abc123\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits behind (3 commits)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '3\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits ahead (2 commits)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '2\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      const result = await orchestrator.detectStaleBranch('old-feature', 'main', '/repo');
+
+      expect(result).toEqual({
+        isStale: true,
+        commitsBehind: 3,
+        commitsAhead: 2,
+        mergeBase: 'xyz789abc123'
+      });
+    });
+
+    it('should detect branch is way behind (many commits)', async () => {
+      const mockExec = vi.mocked(exec);
+
+      // Mock merge-base command
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: 'oldcommit123\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits behind (50 commits)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '50\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits ahead (1 commit)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '1\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      const result = await orchestrator.detectStaleBranch('very-old-branch', 'main');
+
+      expect(result).toEqual({
+        isStale: true,
+        commitsBehind: 50,
+        commitsAhead: 1,
+        mergeBase: 'oldcommit123'
+      });
+    });
+
+    it('should use default parameters when not provided', async () => {
+      const mockExec = vi.mocked(exec);
+
+      // Mock successful execution
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: 'mergebase123\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '0\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '0\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      const result = await orchestrator.detectStaleBranch('test-branch');
+
+      expect(result.isStale).toBe(false);
+      expect(result.commitsBehind).toBe(0);
+      expect(result.commitsAhead).toBe(0);
+
+      // Verify default parameters were used
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('git -C "." merge-base "main" "test-branch"'),
+        expect.any(Object),
+        expect.any(Function)
+      );
+    });
+
+    it('should handle git command errors gracefully', async () => {
+      const mockExec = vi.mocked(exec);
+
+      // Mock git command failure
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(new Error('fatal: Not a valid object name') as any, { stdout: '', stderr: 'fatal: Not a valid object name' } as any);
+        }
+        return {} as any;
+      });
+
+      await expect(orchestrator.detectStaleBranch('non-existent-branch'))
+        .rejects
+        .toThrow('fatal: Not a valid object name');
+    });
+
+    it('should use custom repo path when provided', async () => {
+      const mockExec = vi.mocked(exec);
+      const customPath = '/custom/repo/path';
+
+      // Mock successful execution
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: 'commit123\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '1\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '1\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      await orchestrator.detectStaleBranch('branch', 'main', customPath);
+
+      // Verify custom path was used
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining(`git -C "${customPath}"`),
+        expect.any(Object),
+        expect.any(Function)
+      );
+    });
+
+    it('should handle branches that are equal (same commit)', async () => {
+      const mockExec = vi.mocked(exec);
+
+      // Mock merge-base command
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: 'samecommit\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits behind (0 commits - branches at same point)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '0\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      // Mock rev-list for commits ahead (0 commits - branches at same point)
+      mockExec.mockImplementationOnce((cmd, options, callback) => {
+        if (callback) {
+          callback(null, { stdout: '0\n', stderr: '' } as any);
+        }
+        return {} as any;
+      });
+
+      const result = await orchestrator.detectStaleBranch('same-branch', 'main');
+
+      expect(result).toEqual({
+        isStale: false,
+        commitsBehind: 0,
+        commitsAhead: 0,
+        mergeBase: 'samecommit'
+      });
+    });
+  });
+});

--- a/backend/src/services/prWorkflowOrchestrator.service.ts
+++ b/backend/src/services/prWorkflowOrchestrator.service.ts
@@ -10,6 +10,8 @@
  * This is the entry point for PR workflow after task execution completes.
  */
 
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import { logger } from '../utils/logger.js';
 import { PRMonitorService } from './prMonitor.service.js';
 import { TaskQueueService } from './taskQueue.sqlite.js';
@@ -17,6 +19,8 @@ import type { Task } from './taskQueue.sqlite.js';
 import { PRArtifactRecoveryService } from './prArtifactRecovery.service.js';
 import type { RecoveryStats } from './prArtifactRecovery.service.js';
 import { getGitHubPRService } from './githubPR.service.js';
+
+const execAsync = promisify(exec);
 
 // ============================================================================
 // Types & Interfaces
@@ -372,6 +376,95 @@ export class PRWorkflowOrchestrator {
    */
   getGitHubPRService() {
     return getGitHubPRService();
+  }
+
+  /**
+   * Detect if a branch is stale (behind the base branch)
+   * Uses git commands to determine if a PR branch has diverged from its base
+   *
+   * @param branch The branch name to check (e.g., 'feature-branch')
+   * @param baseBranch The base branch to compare against (default: 'main')
+   * @param repoPath The path to the git repository (default: current directory)
+   * @returns Object containing staleness info: { isStale: boolean, commitsBehind: number, commitsAhead: number }
+   */
+  async detectStaleBranch(
+    branch: string,
+    baseBranch: string = 'main',
+    repoPath: string = '.'
+  ): Promise<{
+    isStale: boolean;
+    commitsBehind: number;
+    commitsAhead: number;
+    mergeBase: string;
+  }> {
+    try {
+      logger.info({
+        category: 'pr-workflow',
+        action: 'detect_stale_branch',
+        message: `Checking if branch '${branch}' is stale compared to '${baseBranch}'`,
+        details: { branch, baseBranch, repoPath }
+      });
+
+      // Step 1: Find the merge base (common ancestor) between the branch and base
+      const { stdout: mergeBase } = await execAsync(
+        `git -C "${repoPath}" merge-base "${baseBranch}" "${branch}"`,
+        { timeout: 10000 }
+      );
+      const mergeBaseCommit = mergeBase.trim();
+
+      logger.debug({
+        category: 'pr-workflow',
+        action: 'merge_base_found',
+        message: `Merge base found: ${mergeBaseCommit}`,
+        details: { branch, baseBranch, mergeBase: mergeBaseCommit }
+      });
+
+      // Step 2: Count commits the branch is behind (commits in base not in branch)
+      const { stdout: behindCount } = await execAsync(
+        `git -C "${repoPath}" rev-list --count "${branch}..${baseBranch}"`,
+        { timeout: 10000 }
+      );
+      const commitsBehind = parseInt(behindCount.trim(), 10);
+
+      // Step 3: Count commits the branch is ahead (commits in branch not in base)
+      const { stdout: aheadCount } = await execAsync(
+        `git -C "${repoPath}" rev-list --count "${baseBranch}..${branch}"`,
+        { timeout: 10000 }
+      );
+      const commitsAhead = parseInt(aheadCount.trim(), 10);
+
+      const isStale = commitsBehind > 0;
+
+      logger.info({
+        category: 'pr-workflow',
+        action: 'stale_branch_detected',
+        message: `Branch '${branch}' is ${isStale ? 'stale' : 'up to date'} (${commitsBehind} behind, ${commitsAhead} ahead)`,
+        details: {
+          branch,
+          baseBranch,
+          isStale,
+          commitsBehind,
+          commitsAhead,
+          mergeBase: mergeBaseCommit
+        }
+      });
+
+      return {
+        isStale,
+        commitsBehind,
+        commitsAhead,
+        mergeBase: mergeBaseCommit
+      };
+    } catch (error) {
+      logger.error({
+        category: 'pr-workflow',
+        action: 'detect_stale_branch_failed',
+        message: `Failed to detect stale branch for '${branch}'`,
+        error,
+        details: { branch, baseBranch, repoPath }
+      });
+      throw error;
+    }
   }
 
 }


### PR DESCRIPTION
Implemented detectStaleBranch() method in PRWorkflowOrchestrator class using git commands (merge-base, rev-list) to detect if a PR branch is stale compared to its base branch.

Method features:
- Uses git merge-base to find common ancestor
- Uses git rev-list to count commits ahead/behind
- Returns staleness status with detailed metrics
- Includes comprehensive error handling and logging
- Follows existing patterns from GitHubPRService

Acceptance criteria:
- [x] detectStaleBranch method added to PRWorkflowOrchestrator
- [x] Uses git merge-base and rev-list commands
- [x] Comprehensive unit tests with 7 test cases
- [x] All tests pass
- [x] No new linter errors

Files modified:
- backend/src/services/prWorkflowOrchestrator.service.ts
- backend/src/services/prWorkflowOrchestrator.service.test.ts (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)