### PR TITLE
implementation: Fix LogLevelBadge color contrast for accessibility

### DIFF
--- a/frontend/src/components/LogLevelBadge.test.tsx
+++ b/frontend/src/components/LogLevelBadge.test.tsx
@@ -7,8 +7,8 @@ describe('LogLevelBadge', () => {
     render(<LogLevelBadge level="ERROR" />);
     const badge = screen.getByText('ERROR');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-destructive/20');
-    expect(badge).toHaveClass('text-destructive-foreground');
+    expect(badge).toHaveClass('bg-red-900/90');
+    expect(badge).toHaveClass('text-red-100');
     expect(badge).toHaveClass('font-mono');
   });
 
@@ -16,23 +16,24 @@ describe('LogLevelBadge', () => {
     render(<LogLevelBadge level="WARN" />);
     const badge = screen.getByText('WARN');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-amber-400/20');
-    expect(badge).toHaveClass('text-amber-200');
+    expect(badge).toHaveClass('bg-amber-900/90');
+    expect(badge).toHaveClass('text-amber-100');
   });
 
   it('renders INFO level with correct styling', () => {
     render(<LogLevelBadge level="INFO" />);
     const badge = screen.getByText('INFO');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-sky-500/20');
-    expect(badge).toHaveClass('text-sky-200');
+    expect(badge).toHaveClass('bg-sky-900/90');
+    expect(badge).toHaveClass('text-sky-100');
   });
 
   it('renders DEBUG level with correct styling', () => {
     render(<LogLevelBadge level="DEBUG" />);
     const badge = screen.getByText('DEBUG');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('text-muted-foreground');
+    expect(badge).toHaveClass('text-foreground');
+    expect(badge).toHaveClass('border-border');
   });
 
   it('has correct base styling', () => {

--- a/frontend/src/components/LogLevelBadge.tsx
+++ b/frontend/src/components/LogLevelBadge.tsx
@@ -1,6 +1,5 @@
 import { LogLevel } from '../types/log.types';
 import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
 
 interface LogLevelBadgeProps {
   level: LogLevel;
@@ -25,10 +24,7 @@ const LogLevelBadge: React.FC<LogLevelBadgeProps> = ({ level }) => {
   return (
     <Badge
       variant={getVariant()}
-      className={cn(
-        'min-w-[48px] justify-center font-mono text-[10px] uppercase tracking-[0.3em]',
-        level === 'DEBUG' && 'text-muted-foreground',
-      )}
+      className="min-w-[48px] justify-center font-mono text-[10px] uppercase tracking-[0.3em]"
     >
       {level}
     </Badge>

--- a/frontend/src/components/StatusBadge.test.tsx
+++ b/frontend/src/components/StatusBadge.test.tsx
@@ -7,7 +7,7 @@ describe('StatusBadge', () => {
     render(<StatusBadge status="running" />);
     const badge = screen.getByText('● Running');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-emerald-500/20', 'text-emerald-200');
+    expect(badge).toHaveClass('bg-emerald-900/90', 'text-emerald-100');
     expect(badge).not.toHaveClass('animate-pulse');
   });
 
@@ -15,7 +15,7 @@ describe('StatusBadge', () => {
     render(<StatusBadge status="stopped" />);
     const badge = screen.getByText('○ Stopped');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-destructive/20');
+    expect(badge).toHaveClass('bg-red-900/90');
     expect(badge).not.toHaveClass('animate-pulse');
   });
 
@@ -23,21 +23,21 @@ describe('StatusBadge', () => {
     render(<StatusBadge status="starting" />);
     const badge = screen.getByText('◐ Starting...');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-amber-400/20', 'animate-pulse');
+    expect(badge).toHaveClass('bg-amber-900/90', 'animate-pulse');
   });
 
   it('renders stopping status correctly', () => {
     render(<StatusBadge status="stopping" />);
     const badge = screen.getByText('◑ Stopping...');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-amber-400/20', 'animate-pulse');
+    expect(badge).toHaveClass('bg-amber-900/90', 'animate-pulse');
   });
 
   it('renders error status correctly', () => {
     render(<StatusBadge status="error" />);
     const badge = screen.getByText('✕ Error');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-destructive/20');
+    expect(badge).toHaveClass('bg-red-900/90');
   });
 
   it('has animation for transitional states (starting)', () => {

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -9,11 +9,11 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: 'border-transparent bg-secondary text-secondary-foreground',
-        success: 'border-transparent bg-emerald-500/20 text-emerald-200',
-        destructive: 'border-transparent bg-destructive/20 text-destructive-foreground',
-        warning: 'border-transparent bg-amber-400/20 text-amber-200',
-        info: 'border-transparent bg-sky-500/20 text-sky-200',
-        outline: 'text-foreground',
+        success: 'border-transparent bg-emerald-900/90 text-emerald-100',
+        destructive: 'border-transparent bg-red-900/90 text-red-100',
+        warning: 'border-transparent bg-amber-900/90 text-amber-100',
+        info: 'border-transparent bg-sky-900/90 text-sky-100',
+        outline: 'text-foreground border-border',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
🤖 Auto-generated from dev-bot task

Fixes color contrast for LogLevelBadge to meet WCAG AA standards.

**Branch:** task-implementation-9a1e083aa455