### PR TITLE
fix: remove broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project is currently in **pre-POC stabilization** phase, preparing the foun
 
 **Note:** Some TypeScript build errors remain in backend. These are being addressed as part of ongoing stabilization work.
 
-📖 For complete stabilization details, see [Stabilization Plan](./docs/plans/APP_MONITOR_STABILIZATION_PLAN.md) and [Capability Roadmap (archived)](./docs/archive/plans-completed-2025-11/APP_MONITOR_CAPABILITY_ROADMAP-completed-2025-11.md).
+📖 For complete stabilization details, see [Stabilization Plan](./docs/plans/APP_MONITOR_STABILIZATION_PLAN.md).
 
 ---
 
@@ -285,13 +285,10 @@ make stop
 - [Frontend Development Guide](./docs/guides/FRONTEND_DEVELOPMENT.md) - Developer workflows and best practices
 
 ### Planning & Roadmap
-- [Next Priority Tasks](./docs/NEXT_PRIORITY_TASKS.md) - Current focus areas
 - [Stabilization Plan](./docs/plans/APP_MONITOR_STABILIZATION_PLAN.md) - Current phase details
-- [Implementation Status](./docs/IMPLEMENTATION_STATUS.md) - Progress tracking
 
 ### Migration & History
 - [Migration Guide](./docs/guides/MIGRATION_GUIDE.md) - Migrating from dev-monitor
-- [Database Migrations](./docs/database-migrations.md) - Database schema changes
 - [Google Cloud Logging](./docs/guides/GOOGLE_CLOUD_LOGGING_PERMISSIONS.md) - GCP IAM setup
 
 ### Contributing

--- a/backend/README.md
+++ b/backend/README.md
@@ -697,11 +697,8 @@ export function getMyService(): MyService {
 
 ## Related Documentation
 
-- [IMPLEMENTATION_STATUS.md](../docs/IMPLEMENTATION_STATUS.md) - Overall project status
-- [OUTSTANDING_CLEANUP_IMPROVEMENTS.md](../docs/analysis/OUTSTANDING_CLEANUP_IMPROVEMENTS.md) - Feature roadmap
-- [CODE_HYGIENE_AND_MAINTAINABILITY_ANALYSIS.md](../docs/analysis/CODE_HYGIENE_AND_MAINTAINABILITY_ANALYSIS.md) - Code quality review
-- [DATABASE_MIGRATION_SAFETY.md](../docs/DATABASE_MIGRATION_SAFETY.md) - Migration guide
-- [DEV_BOTS_ARCHITECTURE_ANALYSIS.md](../docs/analysis/DEV_BOTS_ARCHITECTURE_ANALYSIS.md) - Architecture details
+- [Architecture Overview](../docs/architecture/README.md) - System design and components
+- [Setup Guides](../docs/setup/README.md) - Installation and configuration
 
 ---
 

--- a/backend/docs/PHASE2_MEDIUM_PRIORITY_IMPROVEMENTS.md
+++ b/backend/docs/PHASE2_MEDIUM_PRIORITY_IMPROVEMENTS.md
@@ -451,4 +451,4 @@ The system maintains 100% test coverage for context components and introduces ze
 ## Related Documentation
 
 - [Phase 2 Code Review and Security Fixes](./PHASE2_CODE_REVIEW_FIXES.md)
-- [Dev Bot Context Management System](./technicalDesigns/dev-bot-context-management.md)
+- [Architecture Overview](../../docs/architecture/README.md)

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -4,7 +4,7 @@ This directory contains SQL migration files for the dev-monitor SQLite database.
 
 ## ✨ New Automated Migration System
 
-We now have an elegant migration management system! See [Database Migrations Guide](../../docs/database-migrations.md) for full documentation.
+We now have an elegant migration management system!
 
 ### Quick Start
 
@@ -154,7 +154,7 @@ Implements chain-aware task scheduling that separates implementation tasks (new 
 
 Follows design principle: "Any information available from GitHub should NOT be stored in our DB"
 
-> This avoids data staleness, reduces unnecessary storage, and ensures GitHub remains the source of truth. See [Database Migrations Guide](../../docs/database-migrations.md) for more details.
+> This avoids data staleness, reduces unnecessary storage, and ensures GitHub remains the source of truth.
 
 **Columns Removed**:
 - `pr_url` - Redundant (can construct from pr_number)


### PR DESCRIPTION
Fix failing CI documentation check by removing broken links to non-existent files:
- Remove link to archive directory that doesn't exist
- Remove links to deleted files (database-migrations.md, NEXT_PRIORITY_TASKS.md, IMPLEMENTATION_STATUS.md)
- Remove links to deleted analysis files (OUTSTANDING_CLEANUP_IMPROVEMENTS.md, etc.)
- Replace broken links with existing documentation references

Fixes failing check-documentation workflow in PR #137

🤖 Generated with Claude Code