### PR TITLE
fix: add logWriter null check in logs route

### DIFF
--- a/backend/src/routes/logs.routes.ts
+++ b/backend/src/routes/logs.routes.ts
@@ -53,6 +53,15 @@ interface LogBatch {
  */
 router.post('/frontend', (req: Request, res: Response) => {
   try {
+    // Check if logWriter is initialized
+    if (!logWriter) {
+      res.status(503).json({
+        success: false,
+        error: 'Log writer not initialized',
+      });
+      return;
+    }
+
     const batch = req.body as LogBatch;
 
     // Validate batch


### PR DESCRIPTION
## Bug Fix

**500 error on POST /api/logs/frontend**

### Issue
LogWriter may not be initialized when route is called, causing 500 error.

### Fix
- Added null check before using logWriter
- Returns 503 if not initialized (better than 500)
- Better error message for debugging

### Testing
✅ All tests passing