### PR TITLE
fix: add 'alerts' to LogCategory type to fix build failures

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -33,6 +33,7 @@ if (!fs.existsSync(LOGS_DIR)) {
 type LogLevel = 'debug' | 'info' | 'warning' | 'error';
 type LogSeverity = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
 export type LogCategory =
+  | 'alerts' // Alert management system
   | 'api'
   | 'artifact' // Task artifact tracking
   | 'build'


### PR DESCRIPTION
## Summary
This PR fixes the build failures introduced by PR #190 by adding the missing 'alerts' log category to the LogCategory type.

## Problem
PR #190 introduced an AlertManager service that uses 'alerts' as a log category, but this wasn't defined in the LogCategory type union in logger.ts. This caused TypeScript compilation failures in production deployment.

## Solution
Added 'alerts' as a valid LogCategory in backend/src/utils/logger.ts:36

## Test plan
- [x] Backend builds successfully
- [x] Frontend builds successfully
- [x] All linters pass
- [x] All unit tests pass
- [x] Manual verification completed

## Fixes
- Build Backend and Frontend CI check
- Deployment Smoke Test CI check
- Production deployment run #19410039291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
