### PR TITLE
bugfix: Add 'alerts' LogCategory to fix CI build failures

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -33,6 +33,7 @@ if (!fs.existsSync(LOGS_DIR)) {
 type LogLevel = 'debug' | 'info' | 'warning' | 'error';
 type LogSeverity = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
 export type LogCategory =
+  | 'alerts' // Alert management operations
   | 'api'
   | 'artifact' // Task artifact tracking
   | 'build'


### PR DESCRIPTION
## Summary
This PR fixes the failing CI checks in PR #190 by adding the missing 'alerts' LogCategory to the logger type definition.

## Problem
PR #190 introduced the `AlertManager` service which uses `category: 'alerts'` in structured logging calls, but the `LogCategory` type in `logger.ts` did not include 'alerts' as a valid option. This caused TypeScript compilation errors in:

- Build Backend and Frontend check
- Deployment Smoke Test check

## Changes
- Added `'alerts'` to the `LogCategory` union type in `backend/src/utils/logger.ts`
- Placed alphabetically at the start of the list with descriptive comment: "Alert management operations"

## Related PR
Fixes failing CI checks in PR #190

## Testing
- ✅ Backend build passes
- ✅ Frontend build passes
- ✅ All backend unit tests pass
- ✅ Backend linter passes (only pre-existing warnings)
- ✅ Frontend linter passes
- ✅ Pre-commit hooks pass
- ✅ Pre-push quality checks pass

## Impact
- Fixes TypeScript compilation errors in `alertManager.ts` (lines 42, 65, 86, 98, 111, 148)
- No runtime behavior changes
- Type-only fix to support new AlertManager feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)