### PR TITLE
review-feedback: Sort LogCategory alphabetically for better maintainability

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -36,12 +36,16 @@ export type LogCategory =
   | 'alerts' // Alert management system
   | 'api'
   | 'artifact' // Task artifact tracking
+  | 'automation' // Agent selection and automation
   | 'build'
   | 'circuit-breaker'
+  | 'classification' // Task classification for intelligent agent selection
   | 'cloud'
+  | 'codex-log-parser' // Codex log parsing
   | 'context' // Context bundle generation and caching
   | 'copilot-throttle' // Copilot throttle management
   | 'database'
+  | 'delegation' // Copilot delegation
   | 'docker'
   | 'issue-triage' // Autonomous issue triage and resolution
   | 'lint_error'
@@ -51,6 +55,7 @@ export type LogCategory =
   | 'metrics'
   | 'mirror_debug'
   | 'plan' // AI agent-managed planning system
+  | 'port-manager' // Port management operations
   | 'pr-sync' // PR sync service (event-driven)
   | 'pr-workflow'
   | 'process'
@@ -58,9 +63,6 @@ export type LogCategory =
   | 'quality-gates'
   | 'quality-improvement'
   | 'quality-observation'
-  | 'classification' // Task classification for intelligent agent selection
-  | 'automation' // Agent selection and automation
-  | 'delegation' // Copilot delegation
   | 'recovery'
   | 'safety' // Safety mechanisms for git operations
   | 'scripts'
@@ -72,9 +74,7 @@ export type LogCategory =
   | 'token-tracking'
   | 'utility'
   | 'verification'
-  | 'workspace'
-  | 'port-manager' // Port management operations
-  | 'codex-log-parser'; // Codex log parsing
+  | 'workspace';
 
 export interface LogEntry {
   category: LogCategory;


### PR DESCRIPTION
## Summary
This PR addresses the unresolved review feedback from PR #192 by alphabetically sorting the LogCategory type definition in logger.ts.

## Background
PR #192 was closed as a duplicate of PR #191, which successfully merged the 'alerts' LogCategory. However, PR #192 had an unresolved review comment from Gemini Code Assist suggesting that the entire LogCategory type should be sorted alphabetically for improved maintainability.

## Changes
Alphabetically sorted all categories in the LogCategory union type:
- Moved 'automation' to correct alphabetical position (after 'artifact')
- Moved 'classification' to correct alphabetical position (after 'circuit-breaker')
- Moved 'codex-log-parser' to correct alphabetical position (after 'cloud')
- Moved 'delegation' to correct alphabetical position (after 'database')
- Moved 'port-manager' to correct alphabetical position (after 'plan')

## Benefits
- **Improved maintainability**: Easier to find specific categories
- **Prevents duplicates**: Alphabetical order makes it obvious if a category already exists
- **Better developer experience**: Consistent ordering reduces cognitive load

## Acceptance Criteria
- [x] LogCategory type is fully sorted alphabetically
- [x] No runtime behavior changes (type-only modification)
- [x] All categories retain their comments

## Test plan
- [x] Verified no TypeScript compilation errors specific to LogCategory
- [x] Type-only change - no runtime impact
- [x] All existing code using LogCategory categories continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
